### PR TITLE
feat: PAD-2384: build in CI

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -27,10 +27,8 @@ jobs:
       
     - name: Build and tag image
       run: |
-        COMMIT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
-        docker build . -t communitytechalliance/source-stackadapt:$COMMIT_SHA -t communitytechalliance/source-stackadapt:latest
+        docker build . -t communitytechalliance/source-stackadapt:latest
 
-    - name: Push image to Docker Hub
+    - name: Push image to Docker Hub #todo: only on merge to main
       run: |
-        docker push communitytechalliance/source-stackadapt:$COMMIT_SHA
         docker push communitytechalliance/source-stackadapt:latest

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   publish-source-stackadapt-image:
     runs-on: ubuntu-latest
+    environment:
+      prod
     steps:
     - uses: actions/checkout@v3
 
@@ -31,12 +33,17 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Log in to Docker Hub
+      run: |
+        echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u communitytechalliance --password-stdin
+      
+    - name: Build and tag image
+      run: |
+        COMMIT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
+        docker build . -t communitytechalliance/${{ github.repository }}:$COMMIT_SHA
+
+    - name: Push image to Docker Hub
+      run: docker push communitytechalliance/${{ github.repository }}:$COMMIT_SHA
 
     - name: Build and push
       uses: docker/build-push-action@v3

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -15,18 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Docker Metadata
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        images: |
-          ghcr.io/community-tech-alliance/source-stackadapt
-        tags: |
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=sha
-
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 
@@ -40,15 +28,9 @@ jobs:
     - name: Build and tag image
       run: |
         COMMIT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
-        docker build . -t communitytechalliance/${{ github.repository }}:$COMMIT_SHA
+        docker build . -t communitytechalliance/source-stackadapt:$COMMIT_SHA -t communitytechalliance/source-stackadapt:latest
 
     - name: Push image to Docker Hub
-      run: docker push communitytechalliance/${{ github.repository }}:$COMMIT_SHA
-
-    - name: Build and push
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+      run: |
+        docker push communitytechalliance/source-stackadapt:$COMMIT_SHA
+        docker push communitytechalliance/source-stackadapt:latest

--- a/.github/workflows/build_and_publish_dev.yaml
+++ b/.github/workflows/build_and_publish_dev.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish-source-stackadapt-image:
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name,'dev_deploy') }}
     environment:
       prod
     steps:

--- a/.github/workflows/build_and_publish_dev.yaml
+++ b/.github/workflows/build_and_publish_dev.yaml
@@ -1,0 +1,32 @@
+name: Build image (Dev)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  publish-source-stackadapt-image:
+    runs-on: ubuntu-latest
+    environment:
+      prod
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to Docker Hub
+      run: |
+        echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u communitytechalliance --password-stdin
+      
+    - name: Build and tag image
+      run: |
+        docker build . -t communitytechalliance/source-stackadapt:latest
+
+    - name: Push image to Docker Hub
+      run: |
+        docker push communitytechalliance/source-stackadapt:latest

--- a/.github/workflows/build_and_publish_dev.yaml
+++ b/.github/workflows/build_and_publish_dev.yaml
@@ -25,8 +25,4 @@ jobs:
       
     - name: Build and tag image
       run: |
-        docker build . -t communitytechalliance/source-stackadapt:latest
-
-    - name: Push image to Docker Hub
-      run: |
-        docker push communitytechalliance/source-stackadapt:latest
+        docker build . -t communitytechalliance/source-stackadapt:dev

--- a/.github/workflows/build_and_publish_dev.yaml
+++ b/.github/workflows/build_and_publish_dev.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name,'dev_deploy') }}
     environment:
-      prod
+      prod    #the dockerhub key is the same, update this if new secrets diverge 
     steps:
     - uses: actions/checkout@v3
 
@@ -26,4 +26,9 @@ jobs:
       
     - name: Build and tag image
       run: |
-        docker build . -t communitytechalliance/source-stackadapt:dev
+        COMMIT_HASH=$(echo ${{ github.sha }} | cut -c1-6)
+        docker build . -t communitytechalliance/source-stackadapt:$COMMIT_HASH
+    
+    - name: Push image to Docker Hub
+      run: |
+        docker push communitytechalliance/source-stackadapt:$COMMIT_HASH

--- a/.github/workflows/build_and_publish_prod.yaml
+++ b/.github/workflows/build_and_publish_prod.yaml
@@ -1,11 +1,9 @@
-name: build_and_publish_image
+name: Build image (Prod)
+
 on:
   push:
     branches:
-      - master
-    tags:
-      - v*
-  pull_request:
+      - main
 
 jobs:
   publish-source-stackadapt-image:
@@ -27,8 +25,8 @@ jobs:
       
     - name: Build and tag image
       run: |
-        docker build . -t communitytechalliance/source-stackadapt:latest
+        docker build . -t communitytechalliance/source-stackadapt:dev
 
-    - name: Push image to Docker Hub #todo: only on merge to main
+    - name: Push image to Docker Hub
       run: |
-        docker push communitytechalliance/source-stackadapt:latest
+        docker push communitytechalliance/source-stackadapt:dev

--- a/.github/workflows/build_and_publish_prod.yaml
+++ b/.github/workflows/build_and_publish_prod.yaml
@@ -25,8 +25,8 @@ jobs:
       
     - name: Build and tag image
       run: |
-        docker build . -t communitytechalliance/source-stackadapt:dev
+        docker build . -t communitytechalliance/source-stackadapt:latest
 
     - name: Push image to Docker Hub
       run: |
-        docker push communitytechalliance/source-stackadapt:dev
+        docker push communitytechalliance/source-stackadapt:latest


### PR DESCRIPTION
- On a PR, build + send to docker hub with tag "dev"
- On merges into main, build + send to docker hub with tag "latest".

If this is what we want, I'm going to spam workflows like this around all our other source repos. Questions are: 
- Do we want to upload the the dev images to docker hub? Or do we just care that they build successfully? 